### PR TITLE
feat: gpu-based pre and post processing

### DIFF
--- a/test.html
+++ b/test.html
@@ -53,10 +53,131 @@
     let gl, session, glBinding;
     const maskCanvas = document.getElementById('maskCanvas');
     const maskCtx = maskCanvas.getContext('2d');
-    const tempCanvas = new OffscreenCanvas(224, 224);
-    let pixelBuffer = null;
-    let framebuffer = null;
     let fpsHistory = [];
+
+    // WebGPU resources for fully GPU-based pre/post processing
+    const PREPROCESS_WGSL = `
+      @group(0) @binding(0) var cameraTex : texture_external;
+      @group(0) @binding(1) var<storage, read_write> outBuf : array<f32>;
+      @group(0) @binding(2) var samp : sampler;
+
+      @compute @workgroup_size(8,8)
+      fn main(@builtin(global_invocation_id) gid : vec3<u32>) {
+        if (gid.x >= 224u || gid.y >= 224u) { return; }
+        let uv = (vec2<f32>(gid.xy) + vec2<f32>(0.5)) / vec2<f32>(224.0, 224.0);
+        let rgb = textureSampleLevel(cameraTex, samp, uv, 0.0).rgb;
+        let idx = (gid.y * 224u + gid.x) * 3u;
+        outBuf[idx+0u] = rgb.r;
+        outBuf[idx+1u] = rgb.g;
+        outBuf[idx+2u] = rgb.b;
+      }
+    `;
+
+    const POSTPROCESS_WGSL = `
+      @group(0) @binding(0) var<storage, read> mask : array<f32>;
+      @group(0) @binding(1) var outTex : texture_storage_2d<rgba8unorm, write>;
+
+      @compute @workgroup_size(8,8)
+      fn main(@builtin(global_invocation_id) gid : vec3<u32>) {
+        if (gid.x >= 224u || gid.y >= 224u) { return; }
+        let m = mask[gid.y * 224u + gid.x];
+        let color = vec4<f32>(0.0, 0.0, m, m);
+        textureStore(outTex, vec2<i32>(gid.xy), color);
+      }
+    `;
+
+    let device, queue, preprocessPipeline, postprocessPipeline;
+    let preprocessBuffer, postprocessTexture, sampler;
+
+    async function initGPU() {
+      const adapter = await navigator.gpu.requestAdapter();
+      device = await adapter.requestDevice();
+      queue = device.queue;
+
+      preprocessPipeline = device.createComputePipeline({
+        compute: {
+          module: device.createShaderModule({ code: PREPROCESS_WGSL }),
+          entryPoint: 'main'
+        }
+      });
+
+      postprocessPipeline = device.createComputePipeline({
+        compute: {
+          module: device.createShaderModule({ code: POSTPROCESS_WGSL }),
+          entryPoint: 'main'
+        }
+      });
+
+      preprocessBuffer = device.createBuffer({
+        size: 224 * 224 * 3 * 4,
+        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_READ
+      });
+
+      postprocessTexture = device.createTexture({
+        size: [224, 224],
+        format: 'rgba8unorm',
+        usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_SRC
+      });
+
+      sampler = device.createSampler({ magFilter: 'linear', minFilter: 'linear' });
+    }
+
+    async function preprocess(cameraTex) {
+      const external = device.importExternalTexture({ source: cameraTex });
+      const bind = device.createBindGroup({
+        layout: preprocessPipeline.getBindGroupLayout(0),
+        entries: [
+          { binding: 0, resource: external },
+          { binding: 1, resource: { buffer: preprocessBuffer } },
+          { binding: 2, resource: sampler }
+        ]
+      });
+      const encoder = device.createCommandEncoder();
+      const pass = encoder.beginComputePass();
+      pass.setPipeline(preprocessPipeline);
+      pass.setBindGroup(0, bind);
+      pass.dispatchWorkgroups(Math.ceil(224 / 8), Math.ceil(224 / 8));
+      pass.end();
+      queue.submit([encoder.finish()]);
+      await preprocessBuffer.mapAsync(GPUMapMode.READ);
+      const mapped = preprocessBuffer.getMappedRange().slice(0);
+      preprocessBuffer.unmap();
+      return tf.tensor(new Float32Array(mapped), [1, 224, 224, 3]);
+    }
+
+    async function postprocess(maskTensor) {
+      const data = await maskTensor.data();
+      const upload = device.createBuffer({
+        size: data.byteLength,
+        usage: GPUBufferUsage.COPY_SRC,
+        mappedAtCreation: true
+      });
+      new Float32Array(upload.getMappedRange()).set(data);
+      upload.unmap();
+      const maskBuf = device.createBuffer({
+        size: data.byteLength,
+        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST
+      });
+      const encoder = device.createCommandEncoder();
+      encoder.copyBufferToBuffer(upload, 0, maskBuf, 0, data.byteLength);
+      const bind = device.createBindGroup({
+        layout: postprocessPipeline.getBindGroupLayout(0),
+        entries: [
+          { binding: 0, resource: { buffer: maskBuf } },
+          { binding: 1, resource: postprocessTexture.createView() }
+        ]
+      });
+      const pass = encoder.beginComputePass();
+      pass.setPipeline(postprocessPipeline);
+      pass.setBindGroup(0, bind);
+      pass.dispatchWorkgroups(Math.ceil(224 / 8), Math.ceil(224 / 8));
+      pass.end();
+      queue.submit([encoder.finish()]);
+
+      const bitmap = await createImageBitmap(postprocessTexture);
+      maskCtx.clearRect(0, 0, maskCanvas.width, maskCanvas.height);
+      maskCtx.drawImage(bitmap, 0, 0, maskCanvas.width, maskCanvas.height);
+    }
 
     async function loadModel() {
       try {
@@ -84,6 +205,7 @@
     async function startAR() {
       log("Starting AR...");
       await loadModel();
+      await initGPU();
 
       const canvas = document.createElement('canvas');
       document.body.appendChild(canvas);
@@ -119,29 +241,8 @@
           return;
         }
 
-        const w = view.camera.width;
-        const h = view.camera.height;
-        const size = w * h * 4;
-        if (!pixelBuffer || pixelBuffer.length !== size) {
-          pixelBuffer = new Uint8Array(size);
-        }
-
-        if (!framebuffer) framebuffer = gl.createFramebuffer();
-        gl.bindFramebuffer(gl.FRAMEBUFFER, framebuffer);
-        gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, tex, 0);
-
         const tPreStart = performance.now();
-
-        gl.readPixels(0, 0, w, h, gl.RGBA, gl.UNSIGNED_BYTE, pixelBuffer);
-
-        const input = tf.tidy(() =>
-          tf.tensor(pixelBuffer, [h, w, 4])
-            .slice([0, 0, 0], [h, w, 3])
-            .resizeBilinear([224, 224])
-            .toFloat()
-            .mul(1 / 255)
-            .expandDims()
-        );
+        const input = await preprocess(tex);
         const tPreEnd = performance.now();
 
         const tPredictStart = performance.now();
@@ -152,9 +253,6 @@
         await tf.nextFrame();
         const tPredictEnd = performance.now();
 
-        await tf.browser.toPixels(mask, tempCanvas);
-        const tPostEnd = performance.now();
-
         if (
           maskCanvas.width !== window.innerWidth ||
           maskCanvas.height !== window.innerHeight
@@ -162,9 +260,10 @@
           maskCanvas.width = window.innerWidth;
           maskCanvas.height = window.innerHeight;
         }
-        maskCtx.clearRect(0, 0, maskCanvas.width, maskCanvas.height);
-        maskCtx.drawImage(tempCanvas, 0, 0, maskCanvas.width, maskCanvas.height);
 
+        const tPostStart = performance.now();
+        await postprocess(mask);
+        const tPostEnd = performance.now();
         tf.dispose([input, mask]);
 
         const now = performance.now();


### PR DESCRIPTION
## Summary
- offload preprocessing & mask rendering to WebGPU compute shaders for faster AR segmentation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688fff66e98c8322a41a7ca2e863860d