### PR TITLE
Specify WebGPU pipeline layout

### DIFF
--- a/test.html
+++ b/test.html
@@ -112,6 +112,7 @@
         queue = device.queue;
 
         preprocessPipeline = device.createComputePipeline({
+          layout: 'auto',
           compute: {
             module: device.createShaderModule({ code: PREPROCESS_WGSL }),
             entryPoint: 'main'
@@ -119,6 +120,7 @@
         });
 
         postprocessPipeline = device.createComputePipeline({
+          layout: 'auto',
           compute: {
             module: device.createShaderModule({ code: POSTPROCESS_WGSL }),
             entryPoint: 'main'


### PR DESCRIPTION
## Summary
- ensure compute pipelines use `layout: 'auto'` so WebGPU can initialize

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68900485baec8322b5855d3187fbd307