### PR TITLE
Ensure canvas has sufficient size for WebGPU preprocessing

### DIFF
--- a/test.html
+++ b/test.html
@@ -269,6 +269,8 @@
       }
 
       const canvas = document.createElement('canvas');
+      canvas.width = 224;
+      canvas.height = 224;
       document.body.appendChild(canvas);
       gl = canvas.getContext('webgl', { xrCompatible: true });
 


### PR DESCRIPTION
## Summary
- Set WebGL canvas to 224x224 to prevent copyExternalImageToTexture out-of-bounds errors

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689009e60b288322b3e169a0860d6d82