### PR TITLE
Fix WebGPU postprocess readback alignment

### DIFF
--- a/test.html
+++ b/test.html
@@ -230,13 +230,18 @@
         const bytesPerPixel = 4;
         const alignedBytesPerRow = Math.ceil((224 * bytesPerPixel) / 256) * 256;
 
+        const rowsPerImage = alignedBytesPerRow / bytesPerPixel;
         const readback = device.createBuffer({
-          size: alignedBytesPerRow * 224,
+          size: alignedBytesPerRow * rowsPerImage,
           usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
         });
         encoder.copyTextureToBuffer(
           { texture: postprocessTexture },
-          { buffer: readback, bytesPerRow: alignedBytesPerRow },
+          {
+            buffer: readback,
+            bytesPerRow: alignedBytesPerRow,
+            rowsPerImage,
+          },
           { width: 224, height: 224, depthOrArrayLayers: 1 }
         );
         queue.submit([encoder.finish()]);


### PR DESCRIPTION
## Summary
- avoid WebGPU `copyTextureToBuffer` offset errors by padding readback buffer rows to 256-byte multiples and specifying `rowsPerImage`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689013fb0d648322b1b1554b68da07bd