### PR TITLE
Fix WebGPU buffer copy alignment

### DIFF
--- a/test.html
+++ b/test.html
@@ -230,9 +230,8 @@
         const bytesPerPixel = 4;
         const alignedBytesPerRow = Math.ceil((224 * bytesPerPixel) / 256) * 256;
 
-        const rowsPerImage = alignedBytesPerRow / bytesPerPixel;
         const readback = device.createBuffer({
-          size: alignedBytesPerRow * rowsPerImage,
+          size: alignedBytesPerRow * 224,
           usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
         });
         encoder.copyTextureToBuffer(
@@ -240,7 +239,6 @@
           {
             buffer: readback,
             bytesPerRow: alignedBytesPerRow,
-            rowsPerImage,
           },
           { width: 224, height: 224, depthOrArrayLayers: 1 }
         );


### PR DESCRIPTION
## Summary
- fix WebGPU texture readback alignment to prevent `offset is out of bounds`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890159aa08c83229767674355e74ee0