### PR TITLE
Handle float16 mask output in WebGPU postprocessing

### DIFF
--- a/test.html
+++ b/test.html
@@ -198,7 +198,12 @@
 
     async function postprocess(maskTensor) {
       try {
-        const data = await maskTensor.data();
+        let tensor = maskTensor;
+        if (maskTensor.dtype !== 'float32') {
+          tensor = maskTensor.toFloat();
+        }
+        const data = await tensor.data();
+        if (tensor !== maskTensor) tensor.dispose();
         const upload = device.createBuffer({
           size: data.byteLength,
           usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,


### PR DESCRIPTION
## Summary
- Cast mask tensors to float32 before uploading to GPU buffers
- Dispose temporary tensors to avoid leaks when casting

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890171e772c83228dd7d6db30ee11b8