### PR TITLE
Fix XRWebGLBinding camera image usage

### DIFF
--- a/test.html
+++ b/test.html
@@ -99,8 +99,8 @@
       gl.getExtension('OES_EGL_image_external');
     }
 
-    function drawCameraFrame(frame) {
-      const cameraTex = glBinding.getCameraImage(frame);
+    function drawCameraFrame(view) {
+      const cameraTex = glBinding.getCameraImage(view.camera);
       if (!cameraTex) return false;
       gl.useProgram(cameraProgram);
       gl.activeTexture(gl.TEXTURE0);
@@ -382,9 +382,10 @@
           session.requestAnimationFrame(onFrame);
           return;
         }
+        const view = pose.views[0];
 
         gl.bindFramebuffer(gl.FRAMEBUFFER, session.renderState.baseLayer.framebuffer);
-        if (!drawCameraFrame(frame)) {
+        if (!drawCameraFrame(view)) {
           session.requestAnimationFrame(onFrame);
           return;
         }


### PR DESCRIPTION
## Summary
- Pass XRView's camera to XRWebGLBinding.getCameraImage
- Use extracted view from XRFrame when drawing camera frame

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68901f1cef6483229e5712fc14209f89