### PR TITLE
Fix missing WebGL frame capture in AR segmentation demo

### DIFF
--- a/test.html
+++ b/test.html
@@ -357,7 +357,12 @@
       canvas.width = 224;
       canvas.height = 224;
       document.body.appendChild(canvas);
-      gl = canvas.getContext('webgl', { xrCompatible: true });
+      // Preserve the drawing buffer so createImageBitmap captures the
+      // current camera frame instead of a cleared canvas.
+      gl = canvas.getContext('webgl', {
+        xrCompatible: true,
+        preserveDrawingBuffer: true
+      });
 
       try {
         session = await navigator.xr.requestSession('immersive-ar', {


### PR DESCRIPTION
## Summary
- Preserve WebGL drawing buffer so `createImageBitmap` captures the rendered camera frame

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68902050484c83228003d0c3fc2e0658