### PR TITLE
Ensure texture copy completes before preprocessing

### DIFF
--- a/test.html
+++ b/test.html
@@ -228,6 +228,7 @@
           { texture: cameraTexture },
           [224, 224]
         );
+        await queue.onSubmittedWorkDone();
         const bind = device.createBindGroup({
           layout: preprocessPipeline.getBindGroupLayout(0),
           entries: [


### PR DESCRIPTION
## Summary
- Await completion of WebGPU texture copy before running preprocessing to avoid empty input

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68902900bbf08322b0d6acc10c1abb0e