### PR TITLE
Fix mask postprocessing for WebGPU AR demo

### DIFF
--- a/test.html
+++ b/test.html
@@ -153,8 +153,10 @@
 
     async function postprocess(maskTensor) {
       try {
+        // toPixels expects int32 [0-255] values or float32 [0-1].
+        // maskTensor is float32 0/1, so multiply and cast to int
         await tf.browser.toPixels(
-          tf.tidy(() => maskTensor.mul(255)),
+          tf.tidy(() => maskTensor.mul(255).toInt()),
           tempCanvas
         );
         maskCtx.clearRect(0, 0, maskCanvas.width, maskCanvas.height);


### PR DESCRIPTION
## Summary
- fix `postprocess` to feed `tf.browser.toPixels` int values, avoiding range errors

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689032264f248322b8fc00d12943ef77