### PR TITLE
Guard WebXR canvas initialization against missing event listener

### DIFF
--- a/test.html
+++ b/test.html
@@ -88,8 +88,16 @@
         await tf.setBackend('webgl');
         await tf.ready();
         gl = tf.backend().gl;
-        if (gl && gl.makeXRCompatible) {
-          await gl.makeXRCompatible();
+        if (gl && typeof gl.makeXRCompatible === 'function') {
+          try {
+            if (gl.canvas && typeof gl.canvas.addEventListener === 'function') {
+              await gl.makeXRCompatible();
+            } else {
+              log('Skipping XR compatibility: canvas lacks addEventListener');
+            }
+          } catch (err) {
+            log('XR compatibility error: ' + err.message);
+          }
         }
         log('Using WebGL backend');
         model = await tf.loadLayersModel('jsModel/model.json');


### PR DESCRIPTION
## Summary
- Guard WebXR XR compatibility call by ensuring the canvas supports addEventListener
- Log XR compatibility issues instead of throwing errors

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68907afe145c8322b9184c06b3a7b5d1