### PR TITLE
Handle missing WebGL context in AR page

### DIFF
--- a/test.html
+++ b/test.html
@@ -88,8 +88,12 @@
       try {
         await tf.setBackend('webgl');
         await tf.ready();
-        gl = tf.backend().gl;
-        if (gl && typeof gl.makeXRCompatible === 'function') {
+        const backend = tf.backend();
+        gl = backend?.getGPGPUContext?.().gl || backend?.gpgpu?.gl || backend?.gl;
+        if (!gl) {
+          throw new Error('Failed to obtain WebGL context');
+        }
+        if (typeof gl.makeXRCompatible === 'function') {
           try {
             if (gl.canvas && typeof gl.canvas.addEventListener === 'function') {
               await gl.makeXRCompatible();


### PR DESCRIPTION
## Summary
- Robustly acquire the WebGL context from TensorFlow's backend.
- Add explicit failure path if a WebGL context cannot be obtained.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890814264f08322acad3f3bfe2d4726