### PR TITLE
Fix appendChild error with WebGL OffscreenCanvas

### DIFF
--- a/test.html
+++ b/test.html
@@ -119,10 +119,15 @@
 
         await loadModel();
 
+        // TensorFlow.js may provide an OffscreenCanvas as the WebGL backend's canvas.
+        // OffscreenCanvas is not a DOM node and cannot be appended to the document,
+        // so only append when the canvas is an HTMLCanvasElement.
         const renderCanvas = gl.canvas;
-        renderCanvas.width = window.innerWidth;
-        renderCanvas.height = window.innerHeight;
-        document.body.appendChild(renderCanvas);
+        if (renderCanvas instanceof HTMLCanvasElement) {
+          renderCanvas.width = window.innerWidth;
+          renderCanvas.height = window.innerHeight;
+          document.body.appendChild(renderCanvas);
+        }
 
         session = await navigator.xr.requestSession('immersive-ar', {
           requiredFeatures: ['camera-access', 'dom-overlay'],


### PR DESCRIPTION
## Summary
- Avoid appending OffscreenCanvas to DOM in test.html by checking instance type
- Add explanatory comments around canvas handling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890845159648322bea8f1958dc57980