### PR TITLE
Fix float32 preview tensor range

### DIFF
--- a/test.html
+++ b/test.html
@@ -185,12 +185,10 @@
             const inferenceTime = performance.now() - inferenceStart;
             const mask = tf.sub(1, prediction);
             const preview = inputTensor.squeeze();
-            const previewForCanvas = preview.mul(255);
-
             const postStart = performance.now();
             await Promise.all([
               tf.browser.toPixels(mask, tempCanvas),
-              tf.browser.toPixels(previewForCanvas, inputView)
+              tf.browser.toPixels(preview, inputView)
             ]);
             const postTime = performance.now() - postStart;
 
@@ -199,7 +197,7 @@
             maskCtx.clearRect(0, 0, maskCanvas.width, maskCanvas.height);
             maskCtx.drawImage(tempCanvas, 0, 0, maskCanvas.width, maskCanvas.height);
 
-            tf.dispose([inputTensor, prediction, mask, preview, previewForCanvas]);
+            tf.dispose([inputTensor, prediction, mask, preview]);
             processingLock.busy = false;
 
             const now = performance.now();


### PR DESCRIPTION
## Summary
- avoid scaling camera preview to 0-255 before tf.browser.toPixels to prevent out-of-range float32 error
- adjust tensor disposal to match new preview handling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890a6d620a8832298c5473794fb1940