### PR TITLE
Remove preview thumbnail and streamline postprocess

### DIFF
--- a/test.html
+++ b/test.html
@@ -42,21 +42,11 @@
       border-radius: 5px;
       cursor: pointer;
     }
-    #inputView {
-      position: absolute;
-      top: 60px;
-      left: 10px;
-      width: 112px;
-      height: 112px;
-      z-index: 25;
-      border: 1px solid red;
-    }
   </style>
 </head>
 <body>
   <button id="startBtn">Start AR Segmentation</button>
   <canvas id="maskCanvas"></canvas>
-  <canvas id="inputView"></canvas>
   <div id="info">Status: idle</div>
   <div id="glInfo"></div>
 
@@ -64,7 +54,7 @@
     // Global state variables. They are initialized only after the DOM is
     // fully ready to avoid accessing elements before they exist.
     let model, gl, session, glBinding;
-    let maskCanvas, maskCtx, tempCanvas, inputView;
+    let maskCanvas, maskCtx, tempCanvas;
     let processingLock, fpsHistory;
 
     function log(msg) {
@@ -184,12 +174,8 @@
             await tf.nextFrame();
             const inferenceTime = performance.now() - inferenceStart;
             const mask = tf.sub(1, prediction);
-            const preview = inputTensor.squeeze();
             const postStart = performance.now();
-            await Promise.all([
-              tf.browser.toPixels(mask, tempCanvas),
-              tf.browser.toPixels(preview, inputView)
-            ]);
+            await tf.browser.toPixels(mask, tempCanvas);
             const postTime = performance.now() - postStart;
 
             maskCanvas.width = window.innerWidth;
@@ -197,7 +183,7 @@
             maskCtx.clearRect(0, 0, maskCanvas.width, maskCanvas.height);
             maskCtx.drawImage(tempCanvas, 0, 0, maskCanvas.width, maskCanvas.height);
 
-            tf.dispose([inputTensor, prediction, mask, preview]);
+            tf.dispose([inputTensor, prediction, mask]);
             processingLock.busy = false;
 
             const now = performance.now();
@@ -238,14 +224,6 @@
       tempCanvas = document.createElement('canvas');
       tempCanvas.width = 224;
       tempCanvas.height = 224;
-
-      inputView = document.getElementById('inputView');
-      if (!inputView) {
-        log('inputView is invalid or not found');
-        return;
-      }
-      inputView.width = 224;
-      inputView.height = 224;
 
       processingLock = { busy: false };
       fpsHistory = [];


### PR DESCRIPTION
## Summary
- remove unused preview canvas element and related logic
- streamline postprocessing to only render the mask for faster frames

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890c50001d88322817508641cb186cf