### PR TITLE
fix: guard prediction texture

### DIFF
--- a/test.html
+++ b/test.html
@@ -223,7 +223,14 @@
               const postStart = performance.now();
 
               const texData = tf.backend().texData.get(prediction.dataId);
-              drawMaskFromGLTexture(texData.texture);
+              const maskTex = Array.isArray(texData?.texture)
+                ? texData.texture[0]
+                : texData?.texture;
+              if (maskTex instanceof WebGLTexture) {
+                drawMaskFromGLTexture(maskTex);
+              } else {
+                logGLInfo('Prediction texture missing or invalid');
+              }
               const postTime = performance.now() - postStart;
 
             tf.dispose([inputTensor, prediction]);


### PR DESCRIPTION
## Summary
- Avoid binding invalid textures by verifying tensor texture type

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890d87d5f40832282b091f4bbd8b016