### PR TITLE
Fix mask rendering in AR demo

### DIFF
--- a/test.html
+++ b/test.html
@@ -89,11 +89,14 @@
       quadVBO = gl.createBuffer();
       gl.bindBuffer(gl.ARRAY_BUFFER, quadVBO);
       gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([-1,-1, 1,-1, -1,1, 1,1]), gl.STATIC_DRAW);
+      gl.clearColor(0, 0, 0, 0);
     }
 
     function drawMaskFromGLTexture(texture) {
       if (!shaderProgram) return;
+      gl.bindFramebuffer(gl.FRAMEBUFFER, null);
       gl.viewport(0, 0, gl.canvas.width, gl.canvas.height);
+      gl.clear(gl.COLOR_BUFFER_BIT);
       gl.useProgram(shaderProgram);
       gl.bindBuffer(gl.ARRAY_BUFFER, quadVBO);
       gl.enableVertexAttribArray(posLoc);


### PR DESCRIPTION
## Summary
- Ensure WebGL draws to screen by binding default framebuffer and clearing the canvas
- Set transparent clear color for the mask canvas

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890e033a32c8322ae50133bef20fa9a