### PR TITLE
Fix mask shader to display segmentation overlay

### DIFF
--- a/test.html
+++ b/test.html
@@ -71,12 +71,12 @@ void main() {
   // defaults to 1.0. Sampling the alpha channel would therefore always yield
   // 1.0 and result in the raw camera feed without any overlay. Use the red
   // channel to read the actual mask probability values.
-  float probability = 255.0;
+  float probability = texture(mask, coord).r;
+  vec4 purple = vec4(0.365, 0.247, 0.827, 1.0);
   if (probability > 0.5) {
-    out_color = vec4(src_color.rgb, 255.0);
+    out_color = mix(src_color, purple, 0.5);
   } else {
-    vec4 purple = vec4(0.365, 0.247, 0.827, 1.0);
-    out_color = 0.5 * purple + 0.5 * src_color;
+    out_color = src_color;
   }
   
 }`;


### PR DESCRIPTION
## Summary
- Read mask probability from texture
- Blend purple overlay when probability is high

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68911b2052bc8322b4fcaa3a821fbd04