### PR TITLE
Add WebXR AR demo with 3D model

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,88 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+  <title>Hello WebXR</title>
+  <script src="https://unpkg.com/three@0.126.0/build/three.js"></script>
+  <script src="https://unpkg.com/three@0.126.0/examples/js/loaders/GLTFLoader.js"></script>
+</head>
+<body>
+<button id="startButton">Start AR</button>
+<script>
+async function activateXR() {
+  const canvas = document.createElement('canvas');
+  document.body.appendChild(canvas);
+  const gl = canvas.getContext('webgl', { xrCompatible: true });
+
+  const scene = new THREE.Scene();
+  const light = new THREE.DirectionalLight(0xffffff, 0.8);
+  light.position.set(1, 1, 1);
+  scene.add(light);
+
+  const renderer = new THREE.WebGLRenderer({ canvas, context: gl, alpha: true });
+  renderer.autoClear = false;
+
+  const camera = new THREE.PerspectiveCamera();
+  camera.matrixAutoUpdate = false;
+
+  const session = await navigator.xr.requestSession('immersive-ar', { requiredFeatures: ['hit-test'] });
+  session.updateRenderState({ baseLayer: new XRWebGLLayer(session, gl) });
+
+  const referenceSpace = await session.requestReferenceSpace('local');
+  const viewerSpace = await session.requestReferenceSpace('viewer');
+  const hitTestSource = await session.requestHitTestSource({ space: viewerSpace });
+
+  const loader = new THREE.GLTFLoader();
+  let reticle;
+  loader.load('https://immersive-web.github.io/webxr-samples/media/gltf/reticle/reticle.gltf', (gltf) => {
+    reticle = gltf.scene;
+    reticle.visible = false;
+    scene.add(reticle);
+  });
+
+  let model;
+  loader.load('https://vizbl-1.s3.eu-central-1.amazonaws.com/native/b617533f-d965-4782-8d22-c0574541b809.glb?version=1', (gltf) => {
+    model = gltf.scene;
+  });
+
+  session.addEventListener('select', () => {
+    if (reticle && model) {
+      const clone = model.clone();
+      clone.position.copy(reticle.position);
+      scene.add(clone);
+    }
+  });
+
+  const onXRFrame = (time, frame) => {
+    session.requestAnimationFrame(onXRFrame);
+    gl.bindFramebuffer(gl.FRAMEBUFFER, session.renderState.baseLayer.framebuffer);
+
+    const pose = frame.getViewerPose(referenceSpace);
+    if (pose) {
+      const view = pose.views[0];
+      const viewport = session.renderState.baseLayer.getViewport(view);
+      renderer.setSize(viewport.width, viewport.height);
+
+      camera.matrix.fromArray(view.transform.matrix);
+      camera.projectionMatrix.fromArray(view.projectionMatrix);
+      camera.updateMatrixWorld(true);
+
+      const hitTestResults = frame.getHitTestResults(hitTestSource);
+      if (hitTestResults.length > 0 && reticle) {
+        const hitPose = hitTestResults[0].getPose(referenceSpace);
+        reticle.visible = true;
+        reticle.position.set(hitPose.transform.position.x, hitPose.transform.position.y, hitPose.transform.position.z);
+        reticle.updateMatrixWorld(true);
+      }
+
+      renderer.render(scene, camera);
+    }
+  };
+  session.requestAnimationFrame(onXRFrame);
+}
+
+document.getElementById('startButton').addEventListener('click', activateXR);
+</script>
+</body>
+</html>

--- a/test.html
+++ b/test.html
@@ -57,6 +57,7 @@
     const modelUrl = 'https://vizbl-1.s3.eu-central-1.amazonaws.com/native/b617533f-d965-4782-8d22-c0574541b809.glb?version=1';
     const gltfLoader = new GLTFLoader();
     let gltfModel;
+    let reticle, hitTestSource;
 
       let model, gl, session, glBinding;
     let processingLock, fpsHistory;
@@ -216,12 +217,14 @@
         await loadModel();
 
         session = await navigator.xr.requestSession('immersive-ar', {
-          requiredFeatures: ['camera-access', 'dom-overlay'],
+          requiredFeatures: ['camera-access', 'dom-overlay', 'hit-test'],
           domOverlay: { root: document.body }
         });
 
         session.updateRenderState({ baseLayer: new XRWebGLLayer(session, gl) });
         const referenceSpace = await session.requestReferenceSpace('local');
+        const viewerSpace = await session.requestReferenceSpace('viewer');
+        hitTestSource = await session.requestHitTestSource({ space: viewerSpace });
         glBinding = new XRWebGLBinding(session, gl);
 
         renderer3D = new THREE.WebGLRenderer({ context: gl, alpha: true });
@@ -232,6 +235,12 @@
         camera3D = new THREE.PerspectiveCamera();
         camera3D.matrixAutoUpdate = false;
         applyMask = new MaskStep(renderer3D);
+
+        gltfLoader.load('https://immersive-web.github.io/webxr-samples/media/gltf/reticle/reticle.gltf', (gltf) => {
+          reticle = gltf.scene;
+          reticle.visible = false;
+          scene3D.add(reticle);
+        });
 
         // TensorFlow.js may provide an OffscreenCanvas as the WebGL backend's canvas.
         // OffscreenCanvas is not a DOM node and cannot be appended to the document,
@@ -246,12 +255,18 @@
         try {
           const gltf = await gltfLoader.loadAsync(modelUrl);
           gltfModel = gltf.scene;
-          gltfModel.position.set(0, 0, -1);
           gltfModel.scale.set(0.5, 0.5, 0.5);
-          scene3D.add(gltfModel);
         } catch (e) {
           log('Model load error: ' + e.message);
         }
+
+        session.addEventListener('select', () => {
+          if (gltfModel && reticle) {
+            const clone = gltfModel.clone();
+            clone.position.copy(reticle.position);
+            scene3D.add(clone);
+          }
+        });
 
         let lastFrameTime = performance.now();
 
@@ -311,6 +326,19 @@
               camera3D.matrix.fromArray(view.transform.matrix);
               camera3D.projectionMatrix.fromArray(view.projectionMatrix);
               camera3D.matrixWorldNeedsUpdate = true;
+
+              const hitTestResults = frame.getHitTestResults(hitTestSource);
+              if (hitTestResults.length > 0 && reticle) {
+                const hitPose = hitTestResults[0].getPose(referenceSpace);
+                reticle.visible = true;
+                reticle.position.set(
+                  hitPose.transform.position.x,
+                  hitPose.transform.position.y,
+                  hitPose.transform.position.z
+                );
+                reticle.updateMatrixWorld(true);
+              }
+
               renderer3D.render(scene3D, camera3D);
 
               const postTime = performance.now() - postStart;


### PR DESCRIPTION
## Summary
- Add simple WebXR demo using three.js
- Load GLTF model and place it in AR scene via hit test

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68912f4dd38c83229e0cb35c316d4a1a